### PR TITLE
v1.7.33 - Revamp messaging system and provide means to colorize messages, adding hover and command support

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,12 @@
 # v1.X Changelog
-
+- v1.7.33 - various updates as follows
+  - **FIX**: debugger not closing debug files properly
+  - **FIX**: NPEs related to no-pvp-deaths and more
+  - **FIX**: non-unique config nodes being offered as autocomplete and config set argument
+  - **FIX**: delay kill streak and ELO messages until after the death message has been sent
+  - **FEAT**: player display name feature - uses player names formatted by other plugins
+  - **FEAT**: revamp autocomplete system to allow for partial matches, not only beginning-word-matches
+  - **FEAT**: TextFormatter API that allows for more distinct highlights and information messages, allow information in hover-over, and issuing commands on clicks 
 - v1.6.32 - Make some entries write-only for safety reasons (only mysql connection data for now)
 - v1.6.31 - Rework config command, adjust op messages to provide more information, fix NPE for empty player entry
 - v1.6.30 - Update debugkill, migrate DatabaseAPI to use OfflinePlayer instead of Player

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <repositories>
         <repository>
             <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>slipcor-repo</id>
@@ -24,11 +24,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
             <type>jar</type>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.slipcor</groupId>
@@ -40,7 +39,7 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.10.2</version>
-            <scope>provided</scope>
+            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.slipcor</groupId>
     <artifactId>pvpstats</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <name>PVP Stats</name>
 
     <repositories>

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ This plugin will keep records of how many kills, deaths, kills in a row a player
 
 ## Changelog
 
-- v1.6.32 - Make some entries write-only for safety reasons (only mysql connection data for now)
+- v1.7.33 - Revamp messaging system and provide means to colorize messages, adding hover and command support, more info in changelog!
 - [read more](doc/changelog.md)
 
 ***

--- a/readme.md
+++ b/readme.md
@@ -74,3 +74,12 @@ If you want to disable the tracker, set "bStats.enabled" to false in the __confi
 
 
 ***
+
+## Todos
+
+- Only autocorrect config nodes [when setting or getting] when there is exactly one match.
+  If there is more than one, offer these for proper usage. (Clickable text?)
+- Move language nodes into proper block logic
+- Make as many messages as possible clickable
+
+***

--- a/readme.md
+++ b/readme.md
@@ -77,9 +77,6 @@ If you want to disable the tracker, set "bStats.enabled" to false in the __confi
 
 ## Todos
 
-- Only autocorrect config nodes [when setting or getting] when there is exactly one match.
-  If there is more than one, offer these for proper usage. (Clickable text?)
 - Move language nodes into proper block logic
-- Make as many messages as possible clickable
 
 ***

--- a/src/main/java/net/slipcor/pvpstats/PVPStats.java
+++ b/src/main/java/net/slipcor/pvpstats/PVPStats.java
@@ -135,7 +135,8 @@ public class PVPStats extends JavaPlugin {
                 }
                 String message = announcements.getString(key, "");
                 if (!message.isEmpty()) {
-                    Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', message).replace("%player%", player.getName()));
+                    Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', message)
+                            .replace("%player%", PlayerNameHandler.getPlayerName(player)));
                 }
             }
             if (config().getBoolean(Config.Entry.STATISTICS_STREAK_COMMANDS)) {
@@ -145,7 +146,8 @@ public class PVPStats extends JavaPlugin {
                 }
                 String command = commands.getString(key, "");
                 if (!command.isEmpty()) {
-                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), command.replace("%player%", player.getName()));
+                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(),
+                            command.replace("%player%", PlayerNameHandler.getPlayerName(player)));
                 }
             }
         } catch (IOException | InvalidConfigurationException exception) {

--- a/src/main/java/net/slipcor/pvpstats/PVPStats.java
+++ b/src/main/java/net/slipcor/pvpstats/PVPStats.java
@@ -16,6 +16,8 @@ import net.slipcor.pvpstats.listeners.PlayerListener;
 import net.slipcor.pvpstats.listeners.PluginListener;
 import net.slipcor.pvpstats.metrics.MetricsLite;
 import net.slipcor.pvpstats.metrics.MetricsMain;
+import net.slipcor.pvpstats.text.TextComponent;
+import net.slipcor.pvpstats.text.TextFormatter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -467,7 +469,7 @@ public class PVPStats extends JavaPlugin {
         }
     }
 
-    public void sendPrefixedOP(List<CommandSender> senders, final String message) {
+    public void sendPrefixedOP(List<CommandSender> senders, final TextComponent... message) {
         // if the admin has a config node set to false, noop
         if (!config().getBoolean(Config.Entry.OTHER_OP_MESSAGES)) {
             debugger.i("Would opmsg but config is false");
@@ -480,6 +482,7 @@ public class PVPStats extends JavaPlugin {
         } else {
             // deduplicate
             senders = new ArrayList<>(new HashSet<>(senders));
+            senders.remove(null);
         }
 
         for (CommandSender sender : senders) {
@@ -490,9 +493,9 @@ public class PVPStats extends JavaPlugin {
             }
 
             // otherwise send the message
-            if (!"".equals(message)) {
-                sender.sendMessage(Language.MSG_PREFIX + message);
-                sender.sendMessage(ChatColor.GRAY + "You can disable these messages by setting " + Config.Entry.OTHER_OP_MESSAGES.getNode() + " to false or running command /pvpstats configset " + Config.Entry.OTHER_OP_MESSAGES.getNode() + " false");
+            if (TextFormatter.hasContent(message)) {
+                TextFormatter.send(sender, TextFormatter.addPrefix(message));
+                TextFormatter.explainDisableOPMessages(sender);
             }
         }
     }

--- a/src/main/java/net/slipcor/pvpstats/api/DatabaseAPI.java
+++ b/src/main/java/net/slipcor/pvpstats/api/DatabaseAPI.java
@@ -2,6 +2,7 @@ package net.slipcor.pvpstats.api;
 
 import net.slipcor.pvpstats.PVPStats;
 import net.slipcor.pvpstats.classes.Debugger;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.classes.PlayerStatistic;
 import net.slipcor.pvpstats.core.Config;
 import net.slipcor.pvpstats.core.Language;
@@ -99,12 +100,12 @@ public final class DatabaseAPI {
 
             if (plugin.getSQLHandler().allowsAsync()) {
                 Bukkit.getScheduler().runTaskAsynchronously(PVPStats.getInstance(), new DatabaseKillAddition(
-                        attacker.getName(), attacker.getUniqueId().toString(),
+                        PlayerNameHandler.getPlayerName(attacker), attacker.getUniqueId().toString(),
                         "", "",
                         attacker.getPlayer().getWorld().getName()));
             } else {
                 Bukkit.getScheduler().runTask(PVPStats.getInstance(), new DatabaseKillAddition(
-                        attacker.getName(), attacker.getUniqueId().toString(),
+                        PlayerNameHandler.getPlayerName(attacker), attacker.getUniqueId().toString(),
                         "", "",
                         attacker.getPlayer().getWorld().getName()));
             }
@@ -119,12 +120,12 @@ public final class DatabaseAPI {
             if (plugin.getSQLHandler().allowsAsync()) {
                 Bukkit.getScheduler().runTaskAsynchronously(PVPStats.getInstance(), new DatabaseKillAddition(
                         "", "",
-                        victim.getName(), victim.getUniqueId().toString(),
+                        PlayerNameHandler.getPlayerName(victim), victim.getUniqueId().toString(),
                         victim.getPlayer().getWorld().getName()));
             } else {
                 Bukkit.getScheduler().runTask(PVPStats.getInstance(), new DatabaseKillAddition(
                         "", "",
-                        victim.getName(), victim.getUniqueId().toString(),
+                        PlayerNameHandler.getPlayerName(victim), victim.getUniqueId().toString(),
                         victim.getPlayer().getWorld().getName()));
             }
 
@@ -178,13 +179,13 @@ public final class DatabaseAPI {
         }
         if (plugin.getSQLHandler().allowsAsync()) {
             Bukkit.getScheduler().runTaskAsynchronously(PVPStats.getInstance(), new DatabaseKillAddition(
-                    attacker.getName(), attacker.getUniqueId().toString(),
-                    victim.getName(), victim.getUniqueId().toString(),
+                    PlayerNameHandler.getPlayerName(attacker), attacker.getUniqueId().toString(),
+                    PlayerNameHandler.getPlayerName(victim), victim.getUniqueId().toString(),
                     attacker.getPlayer().getWorld().getName()));
         } else {
             Bukkit.getScheduler().runTask(PVPStats.getInstance(), new DatabaseKillAddition(
-                    attacker.getName(), attacker.getUniqueId().toString(),
-                    victim.getName(), victim.getUniqueId().toString(),
+                    PlayerNameHandler.getPlayerName(attacker), attacker.getUniqueId().toString(),
+                    PlayerNameHandler.getPlayerName(victim), victim.getUniqueId().toString(),
                     attacker.getPlayer().getWorld().getName()));
         }
 
@@ -228,7 +229,8 @@ public final class DatabaseAPI {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
             plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
-            return new PlayerStatistic(player.getName(), 0, 0, 0, 0, 0, 0, player.getUniqueId());
+            return new PlayerStatistic(PlayerNameHandler.getPlayerName(player),
+                    0, 0, 0, 0, 0, 0, player.getUniqueId());
         }
 
         try {
@@ -236,7 +238,8 @@ public final class DatabaseAPI {
         } catch (SQLException e) {
             e.printStackTrace();
         }
-        return new PlayerStatistic(player.getName(), 0, 0, 0, 0, 0, 0, player.getUniqueId());
+        return new PlayerStatistic(PlayerNameHandler.getPlayerName(player),
+                0, 0, 0, 0, 0, 0, player.getUniqueId());
     }
 
     /**
@@ -336,7 +339,7 @@ public final class DatabaseAPI {
             result = plugin.getSQLHandler().getStats(player);
             if (result == null) {
                 String[] output = new String[1];
-                output[0] = Language.INFO_PLAYERNOTFOUND.toString(player.getName());
+                output[0] = Language.INFO_PLAYERNOTFOUND.toString(PlayerNameHandler.getPlayerName(player));
                 return output;
             }
         } catch (SQLException e) {
@@ -345,7 +348,7 @@ public final class DatabaseAPI {
 
         if (result == null) {
             String[] output = new String[1];
-            output[0] = Language.INFO_PLAYERNOTFOUND.toString(player.getName());
+            output[0] = Language.INFO_PLAYERNOTFOUND.toString(PlayerNameHandler.getPlayerName(player));
             output[1] = Language.INFO_PLAYERNOTFOUND2.toString();
             return output;
         }
@@ -426,7 +429,7 @@ public final class DatabaseAPI {
     public static void initiatePlayer(OfflinePlayer player) {
         if (getAllUUIDs().contains(player.getUniqueId())) {
             // an entry exists!
-        } else if (getAllPlayers().contains(player.getName())) {
+        } else if (getAllPlayers().contains(PlayerNameHandler.getPlayerName(player))) {
             // an entry without UUID exists!
             try {
                  plugin.getSQLHandler().setStatUIDByPlayer(player);
@@ -434,7 +437,7 @@ public final class DatabaseAPI {
                 e.printStackTrace();
             }
             allUUIDs.add(player.getUniqueId());
-            allPlayerNames.remove(player.getName());
+            allPlayerNames.remove(PlayerNameHandler.getPlayerName(player));
         } else if (plugin.config().getBoolean(Config.Entry.STATISTICS_CREATE_ON_JOIN)) {
             if (plugin.getSQLHandler().allowsAsync()) {
                 Bukkit.getScheduler().runTaskAsynchronously(PVPStats.getInstance(), new DatabaseFirstEntry(player));
@@ -1134,7 +1137,8 @@ public final class DatabaseAPI {
     private static boolean incDeath(final Player player, int elo) {
         if (player.hasPermission("pvpstats.count")) {
             PlayerStatisticsBuffer.setStreak(player.getUniqueId(), 0);
-            checkAndDo(player.getName(), player.getUniqueId(), false, false, elo, player.getWorld().getName());
+            checkAndDo(PlayerNameHandler.getPlayerName(player), player.getUniqueId(),
+                    false, false, elo, player.getWorld().getName());
             return true;
         }
         return false;
@@ -1149,7 +1153,8 @@ public final class DatabaseAPI {
      */
     public static boolean forceIncDeath(final OfflinePlayer player, int elo) {
         PlayerStatisticsBuffer.setStreak(player.getUniqueId(), 0);
-        checkAndDo(player.getName(), player.getUniqueId(), false, false, elo, "world");
+        checkAndDo(PlayerNameHandler.getPlayerName(player), player.getUniqueId(),
+                false, false, elo, "world");
         return true;
     }
 
@@ -1171,7 +1176,8 @@ public final class DatabaseAPI {
                 }
 
             }
-            checkAndDo(player.getName(), player.getUniqueId(), true, incMaxStreak, elo, player.getWorld().getName());
+            checkAndDo(PlayerNameHandler.getPlayerName(player), player.getUniqueId(),
+                    true, incMaxStreak, elo, player.getWorld().getName());
             return true;
         }
         return false;
@@ -1202,7 +1208,8 @@ public final class DatabaseAPI {
             }
 
         }
-        checkAndDo(player.getName(), player.getUniqueId(), true, incMaxStreak, elo, "world");
+        checkAndDo(PlayerNameHandler.getPlayerName(player), player.getUniqueId(),
+                true, incMaxStreak, elo, "world");
         return true;
     }
 

--- a/src/main/java/net/slipcor/pvpstats/api/DatabaseAPI.java
+++ b/src/main/java/net/slipcor/pvpstats/api/DatabaseAPI.java
@@ -11,11 +11,14 @@ import net.slipcor.pvpstats.impl.FlatFileConnection;
 import net.slipcor.pvpstats.impl.MySQLConnection;
 import net.slipcor.pvpstats.impl.SQLiteConnection;
 import net.slipcor.pvpstats.runnables.*;
+import net.slipcor.pvpstats.text.TextComponent;
+import net.slipcor.pvpstats.text.TextFormatter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -39,6 +42,11 @@ public final class DatabaseAPI {
 
     private static final Debugger DEBUGGER = new Debugger(4);
 
+    private static final Map<String, String> lastKill = new HashMap<>();
+    private static final Map<String, BukkitTask> killTask = new HashMap<>();
+
+    private static final TextComponent DATABASE_CONNECTED = new TextComponent("Warning: Database is not connected! Kills will not be recorded.");
+
     /**
      * Player A killed player B - use this to generally emulate a player kill.
      * <p>
@@ -52,6 +60,37 @@ public final class DatabaseAPI {
         if (attacker.getPlayer() == null && victim.getPlayer() == null) {
             DEBUGGER.i("attacker and victim are null");
             return;
+        }
+
+        if (plugin.config().getBoolean(Config.Entry.STATISTICS_CHECK_ABUSE)) {
+            DEBUGGER.i("- checking abuse");
+            if (lastKill.containsKey(attacker.getName()) && lastKill.get(attacker.getName()).equals(victim.getName())) {
+                TextFormatter.explainAbusePrevention(attacker, victim);
+                DEBUGGER.i("> OUT: " + victim.getName());
+                return; // no logging!
+            }
+
+            lastKill.put(attacker.getName(), victim.getName());
+            int abusesec = plugin.config().getInt(Config.Entry.STATISTICS_ABUSE_SECONDS);
+            if (abusesec > 0) {
+                final String finalAttacker = attacker.getPlayer().getName();
+                class RemoveLater implements Runnable {
+
+                    @Override
+                    public void run() {
+                        lastKill.remove(finalAttacker);
+                        killTask.remove(finalAttacker);
+                    }
+
+                }
+                BukkitTask task = Bukkit.getScheduler().runTaskLater(plugin, new RemoveLater(), abusesec * 20L);
+
+                if (killTask.containsKey(attacker.getName())) {
+                    killTask.get(attacker.getName()).cancel();
+                }
+
+                killTask.put(attacker.getName(), task);
+            }
         }
 
         if (victim.getPlayer() == null) {
@@ -97,11 +136,11 @@ public final class DatabaseAPI {
                 (isNewbie(attacker) || isNewbie(victim))) {
 
             DEBUGGER.i("either one has newbie status", victim.getName());
-            plugin.sendPrefixedOP(Arrays.asList(attacker.getPlayer(), victim.getPlayer()),
-                    "Kill was not recorded as one or both players have 'newbie' status. Add permission node " +
-                            "'pvpstats.nonewbie' to both players to fix this.");
+            TextFormatter.explainNewbieStatus(attacker, victim);
             return;
         }
+        // here we go, PVP!
+        DEBUGGER.i("Counting kill by " + attacker.getName(), victim.getPlayer());
 
         if (!plugin.config().getBoolean(Config.Entry.ELO_ACTIVE)) {
             DEBUGGER.i("no elo", victim.getName());
@@ -160,7 +199,7 @@ public final class DatabaseAPI {
     public static List<UUID> getAllUUIDs() {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
 
@@ -188,7 +227,7 @@ public final class DatabaseAPI {
     public static PlayerStatistic getAllStats(OfflinePlayer player) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return new PlayerStatistic(player.getName(), 0, 0, 0, 0, 0, 0, player.getUniqueId());
         }
 
@@ -206,7 +245,7 @@ public final class DatabaseAPI {
     public static List<String> getAllPlayers() {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
         if (allPlayerNames == null) {
@@ -245,7 +284,7 @@ public final class DatabaseAPI {
 
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
         int result = -1;
@@ -287,7 +326,7 @@ public final class DatabaseAPI {
     public static String[] info(final OfflinePlayer player) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
 
@@ -572,6 +611,7 @@ public final class DatabaseAPI {
         boolean newbie = p.hasPermission("pvpstats.newbie");
 
         if (p.hasPermission("pvpstats.null")) {
+            DEBUGGER.i("Player has ALL permissions, we assume they are not newbie...");
             /*
              * If a player does have the previous permission, we can assume that the permission
              * plugin either does always reply with TRUE or has ALL PERMS set to true, which means
@@ -585,6 +625,7 @@ public final class DatabaseAPI {
 
 
         if (newbie) {
+            DEBUGGER.i("Player has 'newbie'...");
             // backwards compatibility until we have a warning system in place to ask admins to change to
             // proper permission logic
             return true;
@@ -602,7 +643,7 @@ public final class DatabaseAPI {
     public static int purgeKillStats(int days) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return 0;
         }
 
@@ -628,7 +669,7 @@ public final class DatabaseAPI {
     public static int purgeStats(int days) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return 0;
         }
         int count = 0;
@@ -678,7 +719,7 @@ public final class DatabaseAPI {
     public static String[] top(final int count, String sort) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
 
@@ -777,7 +818,7 @@ public final class DatabaseAPI {
     public static String[] flop(final int count, String sort) {
         if (!plugin.getSQLHandler().isConnected()) {
             plugin.getLogger().severe("Database is not connected!");
-            plugin.sendPrefixedOP(new ArrayList<>(), "Warning: Database is not connected! Kills will not be recorded.");
+            plugin.sendPrefixedOP(new ArrayList<>(), DATABASE_CONNECTED);
             return null;
         }
 

--- a/src/main/java/net/slipcor/pvpstats/api/PlayerStatisticsBuffer.java
+++ b/src/main/java/net/slipcor/pvpstats/api/PlayerStatisticsBuffer.java
@@ -5,7 +5,6 @@ import net.slipcor.pvpstats.classes.PlayerStatistic;
 import net.slipcor.pvpstats.core.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 
 import java.util.*;
 

--- a/src/main/java/net/slipcor/pvpstats/api/PlayerStatisticsBuffer.java
+++ b/src/main/java/net/slipcor/pvpstats/api/PlayerStatisticsBuffer.java
@@ -56,7 +56,17 @@ public final class PlayerStatisticsBuffer {
      */
     public static boolean addStreak(UUID uuid) {
         final int streak = streaks.get(uuid) + 1;
-        PVPStats.getInstance().handleStreak(uuid, streak);
+
+        Bukkit.getScheduler().runTaskLaterAsynchronously(
+                PVPStats.getInstance(), new Runnable() {
+                    @Override
+                    public void run() {
+                        // issue streak commands AFTER the death message has gone through
+                        PVPStats.getInstance().handleStreak(uuid, streak);
+                    }
+                }, 1L
+        );
+
         streaks.put(uuid, streak);
         if (hasMaxStreak(uuid)) {
             if (PlayerStatisticsBuffer.maxStreaks.get(uuid) < streak) {

--- a/src/main/java/net/slipcor/pvpstats/classes/Debugger.java
+++ b/src/main/java/net/slipcor/pvpstats/classes/Debugger.java
@@ -139,15 +139,14 @@ public class Debugger {
 
         loggers.clear();
 
-        if ("off".equals(debugs)) {
+        if ("off".equalsIgnoreCase(debugs) || "none".equalsIgnoreCase(debugs) || "false".equalsIgnoreCase(debugs)) {
             if (isPlayer) {
                 sender.sendMessage("debugging: off");
             } else {
                 PVPStats.getInstance().getLogger().info("debugging: off");
             }
-
         } else {
-            if ("on".equalsIgnoreCase(debugs) || "full".equalsIgnoreCase(debugs)) {
+            if ("on".equalsIgnoreCase(debugs) || "full".equalsIgnoreCase(debugs) || "true".equalsIgnoreCase(debugs)) {
                 Debugger.check.add(666);
                 override = true;
                 if (isPlayer) {
@@ -183,6 +182,7 @@ public class Debugger {
             final Handler[] handlers = log.getHandlers().clone();
             for (final Handler hand : handlers) {
                 log.removeHandler(hand);
+                hand.close();
             }
         }
         Debugger.loggers.clear();

--- a/src/main/java/net/slipcor/pvpstats/classes/PlayerDamageHistory.java
+++ b/src/main/java/net/slipcor/pvpstats/classes/PlayerDamageHistory.java
@@ -1,6 +1,5 @@
 package net.slipcor.pvpstats.classes;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.*;

--- a/src/main/java/net/slipcor/pvpstats/classes/PlayerNameHandler.java
+++ b/src/main/java/net/slipcor/pvpstats/classes/PlayerNameHandler.java
@@ -1,6 +1,9 @@
 package net.slipcor.pvpstats.classes;
 
+import net.slipcor.pvpstats.PVPStats;
+import net.slipcor.pvpstats.core.Config;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 
 public class PlayerNameHandler {
@@ -11,11 +14,32 @@ public class PlayerNameHandler {
             if (off.getName().equalsIgnoreCase(value)) {
                 return off;
             }
+            if (off.getPlayer() != null && off.getPlayer().getDisplayName().toLowerCase().contains(value.toLowerCase())) {
+                return off;
+            }
             if (result == null && off.getName().toLowerCase().contains(value.toLowerCase())) {
                 result = off;
             }
         }
         // only return match if no exact result was found
         return result;
+    }
+
+    public static String getPlayerName(OfflinePlayer offlinePlayer) {
+        if (PVPStats.getInstance().config().getBoolean(Config.Entry.OTHER_DISPLAYNAMES)) {
+            if (offlinePlayer.getPlayer() != null) {
+                return offlinePlayer.getPlayer().getDisplayName();
+            }
+        }
+        return offlinePlayer.getName();
+    }
+
+    public static String getRawPlayerName(OfflinePlayer offlinePlayer) {
+        if (PVPStats.getInstance().config().getBoolean(Config.Entry.OTHER_DISPLAYNAMES)) {
+            if (offlinePlayer.getPlayer() != null) {
+                return ChatColor.stripColor(offlinePlayer.getPlayer().getDisplayName());
+            }
+        }
+        return offlinePlayer.getName();
     }
 }

--- a/src/main/java/net/slipcor/pvpstats/commands/AbstractCommand.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/AbstractCommand.java
@@ -18,7 +18,7 @@ public abstract class AbstractCommand {
     }
 
     protected void addIfMatches(List<String> list, String word, String check) {
-        if (check.equals("") || word.toLowerCase().startsWith(check.toLowerCase())) {
+        if (check.equals("") || word.toLowerCase().contains(check.toLowerCase())) {
             list.add(word);
         }
     }

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandConfig.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandConfig.java
@@ -73,14 +73,35 @@ public class CommandConfig extends AbstractCommand {
         PVPStats.getInstance().sendPrefixed(sender, getShortInfo());
     }
 
-    private void add(final CommandSender sender, final String node, final String value) {
+    private Config.Entry getFullNode(String part) {
+
+        boolean foundEntry = false;
+        Config.Entry completedEntry = null;
 
         for (Config.Entry entry : Config.Entry.values()) {
-            if (entry.getNode().toLowerCase().endsWith('.' + node.toLowerCase())) {
-                // get the actual full proper node
-                add(sender, entry.getNode(), value);
-                return;
+            if (entry.getNode().toLowerCase().contains(part.toLowerCase()) && entry.getNode().length() != part.length()) {
+                if (foundEntry) {
+                    // found a second match, let us not autocomplete this!
+                    foundEntry = false;
+                    completedEntry = null;
+                    break;
+                }
+                foundEntry = true;
+                completedEntry = entry;
             }
+        }
+
+        return completedEntry;
+    }
+
+    private void add(final CommandSender sender, final String node, final String value) {
+
+        Config.Entry completedEntry = getFullNode(node);
+
+        if (completedEntry != null) {
+            // get the actual full proper node
+            add(sender, completedEntry.getNode(), value);
+            return;
         }
 
         final Config.Entry entry = Config.Entry.getByNode(node);
@@ -114,12 +135,12 @@ public class CommandConfig extends AbstractCommand {
 
     private void get(final CommandSender sender, final String node) {
 
-        for (Config.Entry entry : Config.Entry.values()) {
-            if (entry.getNode().toLowerCase().endsWith('.' + node.toLowerCase())) {
-                // get the actual full proper node
-                get(sender, entry.getNode());
-                return;
-            }
+        Config.Entry completedEntry = getFullNode(node);
+
+        if (completedEntry != null) {
+            // get the actual full proper node
+            get(sender, completedEntry.getNode());
+            return;
         }
 
         final Config.Entry entry = Config.Entry.getByNode(node);
@@ -163,12 +184,12 @@ public class CommandConfig extends AbstractCommand {
 
     private void remove(final CommandSender sender, final String node, final String value) {
 
-        for (Config.Entry entry : Config.Entry.values()) {
-            if (entry.getNode().toLowerCase().endsWith('.' + node.toLowerCase())) {
-                // get the actual full proper node
-                remove(sender, entry.getNode(), value);
-                return;
-            }
+        Config.Entry completedEntry = getFullNode(node);
+
+        if (completedEntry != null) {
+            // get the actual full proper node
+            remove(sender, completedEntry.getNode(), value);
+            return;
         }
 
         final Config.Entry entry = Config.Entry.getByNode(node);
@@ -202,12 +223,12 @@ public class CommandConfig extends AbstractCommand {
 
     private void set(final CommandSender sender, final String node, final String value) {
 
-        for (Config.Entry entry : Config.Entry.values()) {
-            if (entry.getNode().toLowerCase().endsWith('.' + node.toLowerCase())) {
-                // get the actual full proper node
-                set(sender, entry.getNode(), value);
-                return;
-            }
+        Config.Entry completedEntry = getFullNode(node);
+
+        if (completedEntry != null) {
+            // get the actual full proper node
+            set(sender, completedEntry.getNode(), value);
+            return;
         }
 
         final Config.Entry entry = Config.Entry.getByNode(node);

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandDebugKill.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandDebugKill.java
@@ -52,7 +52,7 @@ public class CommandDebugKill extends AbstractCommand {
         if (args.length < 2 || args[1].equals("")) {
             // list first argument possibilities
             for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-                results.add(p.getName());
+                results.add(PlayerNameHandler.getRawPlayerName(p));
             }
             return results;
         }

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandDebugKill.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandDebugKill.java
@@ -2,12 +2,9 @@ package net.slipcor.pvpstats.commands;
 
 import net.slipcor.pvpstats.PVPStats;
 import net.slipcor.pvpstats.api.DatabaseAPI;
-import net.slipcor.pvpstats.api.PlayerStatisticsBuffer;
 import net.slipcor.pvpstats.classes.Debugger;
-import net.slipcor.pvpstats.core.Config;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.core.Language;
-import net.slipcor.pvpstats.display.SignDisplay;
-import net.slipcor.pvpstats.runnables.DatabaseKillAddition;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -66,7 +63,7 @@ public class CommandDebugKill extends AbstractCommand {
 
         // we started typing!
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            addIfMatches(results, p.getName(), p.getName());
+            addIfMatches(results, p.getName(), args[1]);
         }
         return results;
     }

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandSet.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandSet.java
@@ -9,7 +9,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -86,10 +85,9 @@ public class CommandSet extends AbstractCommand {
         }
 
         if (args.length < 3) {
-
             // first argument!
             for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-                results.add(p.getName());
+                addIfMatches(results, p.getName(), args[1].toLowerCase());
             }
         } else {
 

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandShow.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandShow.java
@@ -1,7 +1,6 @@
 package net.slipcor.pvpstats.commands;
 
 import net.slipcor.pvpstats.PVPStats;
-import net.slipcor.pvpstats.api.DatabaseAPI;
 import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.runnables.SendPlayerStats;
 import org.bukkit.Bukkit;
@@ -79,7 +78,7 @@ public class CommandShow extends AbstractCommand {
         // we started typing!
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             if (!isVanished(p)) {
-                addIfMatches(results, p.getName(), p.getName());
+                addIfMatches(results, p.getName(), args[1]);
             }
         }
         return results;

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandTop.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandTop.java
@@ -1,7 +1,6 @@
 package net.slipcor.pvpstats.commands;
 
 import net.slipcor.pvpstats.PVPStats;
-import net.slipcor.pvpstats.api.DatabaseAPI;
 import net.slipcor.pvpstats.core.Language;
 import net.slipcor.pvpstats.runnables.SendPlayerTop;
 import org.bukkit.Bukkit;

--- a/src/main/java/net/slipcor/pvpstats/commands/CommandWipe.java
+++ b/src/main/java/net/slipcor/pvpstats/commands/CommandWipe.java
@@ -60,7 +60,7 @@ public class CommandWipe extends AbstractCommand {
 
         // we started typing!
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            addIfMatches(results, p.getName(), p.getName());
+            addIfMatches(results, p.getName(), args[1]);
         }
         return results;
     }

--- a/src/main/java/net/slipcor/pvpstats/core/Config.java
+++ b/src/main/java/net/slipcor/pvpstats/core/Config.java
@@ -1,6 +1,5 @@
 package net.slipcor.pvpstats.core;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.commons.lang.ObjectUtils.Null;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -144,7 +143,8 @@ public class Config {
                 "# which type of branch to get updates? Valid values: dev, alpha, beta, release"}),
 
         OTHER(Null.class, "other", null, new String[]{
-                "# === [ Integration into other Plugins ] ==="}),
+                "# === [ Other Features ] ==="}),
+        OTHER_DISPLAYNAMES(Boolean.class, "other.displayNames", false, new String[]{"# use players' display names"}),
         OTHER_PVPARENA(Boolean.class, "other.PVPArena", false, new String[]{"# count PVP Arena deaths"}),
         OTHER_OP_MESSAGES(Boolean.class, "other.OPMessages", true, new String[]{"# provide helpful debug messages for new installations"}),
 

--- a/src/main/java/net/slipcor/pvpstats/core/TabComplete.java
+++ b/src/main/java/net/slipcor/pvpstats/core/TabComplete.java
@@ -4,7 +4,9 @@ package net.slipcor.pvpstats.core;
 import net.slipcor.pvpstats.commands.AbstractCommand;
 import org.bukkit.command.CommandSender;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public final  class TabComplete {
     private TabComplete() {}

--- a/src/main/java/net/slipcor/pvpstats/impl/AbstractSQLConnection.java
+++ b/src/main/java/net/slipcor/pvpstats/impl/AbstractSQLConnection.java
@@ -1,6 +1,7 @@
 package net.slipcor.pvpstats.impl;
 
 import net.slipcor.pvpstats.api.DatabaseConnection;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.classes.PlayerStatistic;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -9,7 +10,9 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * A partial implementation of methods that are handled the same by all SQL implementations
@@ -315,7 +318,8 @@ public abstract class AbstractSQLConnection implements DatabaseConnection {
                     UUID.fromString(result.getString("uid")));
         }
         return new PlayerStatistic(
-                offlinePlayer.getName(), 0, 0, 0, 0, 0, 0,
+                PlayerNameHandler.getPlayerName(offlinePlayer),
+                0, 0, 0, 0, 0, 0,
                 offlinePlayer.getUniqueId());
     }
 

--- a/src/main/java/net/slipcor/pvpstats/impl/FlatFileConnection.java
+++ b/src/main/java/net/slipcor/pvpstats/impl/FlatFileConnection.java
@@ -2,6 +2,7 @@ package net.slipcor.pvpstats.impl;
 
 import net.slipcor.pvpstats.PVPStats;
 import net.slipcor.pvpstats.api.DatabaseConnection;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.classes.PlayerStatistic;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
@@ -397,7 +398,8 @@ public class FlatFileConnection implements DatabaseConnection {
         ConfigurationSection player = statConfig.getConfigurationSection(offlinePlayer.getUniqueId().toString());
 
         if (player == null) {
-            return new PlayerStatistic(offlinePlayer.getName(), 0, 0, 0, 0, 0, 0, offlinePlayer.getUniqueId());
+            return new PlayerStatistic(PlayerNameHandler.getPlayerName(offlinePlayer),
+                    0, 0, 0, 0, 0, 0, offlinePlayer.getUniqueId());
         }
 
         return new PlayerStatistic(player.getString("name", ""),

--- a/src/main/java/net/slipcor/pvpstats/impl/MySQLConnection.java
+++ b/src/main/java/net/slipcor/pvpstats/impl/MySQLConnection.java
@@ -4,7 +4,6 @@ import org.bukkit.Bukkit;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 
 /**
  * Based on MySQLConnection by Jesika(Kaitlyn) Tremaine aka JesiKat

--- a/src/main/java/net/slipcor/pvpstats/impl/SQLiteConnection.java
+++ b/src/main/java/net/slipcor/pvpstats/impl/SQLiteConnection.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.List;
 
 public class SQLiteConnection extends AbstractSQLConnection {
     // SQL connection details

--- a/src/main/java/net/slipcor/pvpstats/listeners/PlayerListener.java
+++ b/src/main/java/net/slipcor/pvpstats/listeners/PlayerListener.java
@@ -24,9 +24,11 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.scheduler.BukkitTask;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Player Event Listener class

--- a/src/main/java/net/slipcor/pvpstats/runnables/DatabaseFirstEntry.java
+++ b/src/main/java/net/slipcor/pvpstats/runnables/DatabaseFirstEntry.java
@@ -1,9 +1,9 @@
 package net.slipcor.pvpstats.runnables;
 
 import net.slipcor.pvpstats.PVPStats;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.core.Config;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 
 public class DatabaseFirstEntry implements Runnable {
     private final OfflinePlayer player;
@@ -13,7 +13,7 @@ public class DatabaseFirstEntry implements Runnable {
     @Override
     public void run() {
         PVPStats.getInstance().getSQLHandler().addFirstStat(
-                player.getName(), player.getUniqueId(), 0, 0,
+                PlayerNameHandler.getPlayerName(player), player.getUniqueId(), 0, 0,
                 PVPStats.getInstance().config().getInt(Config.Entry.ELO_DEFAULT));
     }
 }

--- a/src/main/java/net/slipcor/pvpstats/runnables/DatabaseIncreaseDeaths.java
+++ b/src/main/java/net/slipcor/pvpstats/runnables/DatabaseIncreaseDeaths.java
@@ -2,8 +2,6 @@ package net.slipcor.pvpstats.runnables;
 
 import net.slipcor.pvpstats.PVPStats;
 import net.slipcor.pvpstats.classes.Debugger;
-import net.slipcor.pvpstats.core.Config;
-import org.bukkit.entity.Player;
 
 import java.util.UUID;
 

--- a/src/main/java/net/slipcor/pvpstats/text/TextComponent.java
+++ b/src/main/java/net/slipcor/pvpstats/text/TextComponent.java
@@ -1,0 +1,140 @@
+package net.slipcor.pvpstats.text;
+
+import org.bukkit.ChatColor;
+
+public class TextComponent {
+    private final String text;
+    private boolean underline;
+    private boolean bold;
+    private boolean italic;
+    private boolean striked;
+    private ChatColor color = ChatColor.WHITE;
+    private String command;
+    private TextComponent hoverText;
+
+    public TextComponent(String text) {
+        if (text == null || text.isEmpty()) {
+            throw new IllegalArgumentException("Text cannot be empty!");
+        }
+        this.text = text;
+    }
+
+    // GETTERS
+
+    public ChatColor getColor() {
+        return this.color;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public TextComponent getHoverText() {
+        return this.hoverText;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public boolean isBold() {
+        return this.bold;
+    }
+
+    public boolean isItalic() {
+        return this.italic;
+    }
+
+    public boolean isStriked() {
+        return this.striked;
+    }
+
+    public boolean isUnderlined() {
+        return this.underline;
+    }
+
+    // SETTERS
+    
+    public TextComponent setBold(boolean bold) {
+        this.bold = bold;
+        return this;
+    }
+
+    public TextComponent setCommand(String command) {
+        this.command = command;
+        return this;
+    }
+
+    public TextComponent setColor(ChatColor color) {
+        this.color = color;
+        return this;
+    }
+
+    public TextComponent setHoverText(TextComponent hoverText) {
+        if (this.equals(hoverText)) {
+            throw new IllegalArgumentException("Cannot set hover to itself!");
+        }
+        if (hoverText.hoverText != null) {
+            throw new IllegalArgumentException("Hover cannot have hover!");
+        }
+        this.hoverText = hoverText;
+        return this;
+    }
+    
+    public TextComponent setItalic(boolean italic) {
+        this.italic = italic;
+        return this;
+    }
+    
+    public TextComponent setStriked(boolean striked) {
+        this.striked = striked;
+        return this;
+    }
+    
+    public TextComponent setUnderlined(boolean underline) {
+        this.underline = underline;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        if (hoverText != null && hoverText.hoverText != null) {
+            throw new IllegalArgumentException("Hover cannot have hover!");
+        }
+        StringBuffer result = new StringBuffer("{\"text\":\"");
+
+        result.append(text);
+        result.append('"'); // we are done with the main text, now let us look for variables
+
+        if (isBold()) {
+            result.append(",\"bold\":true");
+        }
+        if (isItalic()) {
+            result.append(",\"italic\":true");
+        }
+        if (isStriked()) {
+            result.append(",\"strikethrough\":true");
+        }
+        if (isUnderlined()) {
+            result.append(",\"underlined\":true");
+        }
+        if (getColor() != ChatColor.WHITE) {
+            result.append(",\"color\":\"");
+            result.append(getColor().name().toLowerCase());
+            result.append('"');
+        }
+        if (command != null) {
+            result.append(",\"clickEvent\":{\"action\":\"run_command\",\"value\":\"");
+            result.append(command);
+            result.append("\"}");
+        }
+        if (hoverText != null) {
+            result.append(",\"hoverEvent\":{\"action\":\"show_text\",\"contents\":");
+            result.append(hoverText.toString());
+            result.append('}');
+        }
+        result.append('}');
+
+        return result.toString();
+    }
+}

--- a/src/main/java/net/slipcor/pvpstats/text/TextFormatter.java
+++ b/src/main/java/net/slipcor/pvpstats/text/TextFormatter.java
@@ -1,0 +1,208 @@
+package net.slipcor.pvpstats.text;
+
+import net.slipcor.pvpstats.PVPStats;
+import net.slipcor.pvpstats.core.Config;
+import net.slipcor.pvpstats.core.Language;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class TextFormatter {
+
+
+    public static TextComponent[] addPrefix(TextComponent[] message) {
+        TextComponent[] prefix = TextFormatter.toTextComponent(Language.MSG_PREFIX.toString());
+        TextComponent[] result = Arrays.copyOf(prefix, message.length + prefix.length);
+        System.arraycopy(message, 0, result, prefix.length, message.length);
+        return result;
+    }
+
+    private static TextComponent[] toTextComponent(String string) {
+        if (string.contains("&")) {
+            string = ChatColor.translateAlternateColorCodes('&', string);
+        }
+
+        if (!string.contains("§")) {
+            // plain text
+            return new TextComponent[]{new TextComponent(string)};
+        }
+
+        String[] parts = string.split("§");
+        List<TextComponent> list = new ArrayList<>();
+
+        boolean underline = false;
+        boolean italic = false;
+        boolean bold = false;
+        boolean strike = false;
+        ChatColor color  = ChatColor.WHITE;
+
+        for (String entry : parts) {
+            if (list.isEmpty()) {
+                list.add(new TextComponent(entry));
+            } else {
+                ChatColor chatColor = ChatColor.getByChar(entry.charAt(0));
+                switch (chatColor) {
+
+                    case BLACK:
+                    case DARK_BLUE:
+                    case DARK_GREEN:
+                    case DARK_AQUA:
+                    case DARK_RED:
+                    case DARK_PURPLE:
+                    case GOLD:
+                    case GRAY:
+                    case DARK_GRAY:
+                    case BLUE:
+                    case GREEN:
+                    case AQUA:
+                    case RED:
+                    case LIGHT_PURPLE:
+                    case YELLOW:
+                    case WHITE:
+                        color = chatColor;
+                        break;
+                    case MAGIC:
+                        // ignore
+                        break;
+                    case BOLD:
+                        bold = true;
+                        break;
+                    case STRIKETHROUGH:
+                        strike = true;
+                        break;
+                    case UNDERLINE:
+                        underline = true;
+                        break;
+                    case ITALIC:
+                        italic = true;
+                        break;
+                    case RESET:
+                        bold = false;
+                        strike = false;
+                        underline = false;
+                        italic = false;
+                        color = ChatColor.WHITE;
+                        break;
+                }
+                String content = entry.substring(1);
+                if (!content.isEmpty()) {
+                    list.add(new TextComponent(content).setUnderlined(underline).setColor(color).setBold(bold).setStriked(strike).setItalic(italic));
+                }
+            }
+        }
+
+        return list.toArray(new TextComponent[0]);
+    }
+
+
+    public static void send(CommandSender sender, TextComponent... components) {
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
+            StringBuffer rawCommand = new StringBuffer("tellraw " + player.getName() + " [\"\"");
+
+            for (TextComponent component : components) {
+                rawCommand.append(",");
+                rawCommand.append(component.toString());
+            }
+
+            rawCommand.append(']');
+
+            Bukkit.getServer().dispatchCommand(
+                    Bukkit.getConsoleSender(),
+                    rawCommand.toString());
+        } else {
+            StringBuffer result = new StringBuffer("");
+            for (TextComponent component : components) {
+                result.append(component.getColor() + component.getText());
+            }
+            PVPStats.getInstance().getLogger().info(result.toString());
+        }
+    }
+
+    public static void explainDisableOPMessages(CommandSender sender) {
+        List<TextComponent> components = new ArrayList<>();
+
+        String command = "/pvpstats config set " + Config.Entry.OTHER_OP_MESSAGES.getNode() + " false";
+
+        components.add(new TextComponent("You can disable these messages by setting ").setColor(ChatColor.GRAY));
+        components.add(new TextComponent(Config.Entry.OTHER_OP_MESSAGES.getNode()).setColor(ChatColor.YELLOW));
+        components.add(new TextComponent(" to false or running command ").setColor(ChatColor.GRAY));
+        components.add(new TextComponent(command).setColor(ChatColor.YELLOW).setCommand(command).setUnderlined(true));
+
+        send(sender, components.toArray(new TextComponent[0]));
+    }
+
+    public static boolean hasContent(TextComponent[] components) {
+        if (components == null || components.length < 1) {
+            return false;
+        }
+        for (TextComponent component : components) {
+            if (component.getText() != null && !component.getText().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void explainAbusePrevention(OfflinePlayer attacker, OfflinePlayer victim) {
+        List<TextComponent> message = new ArrayList<>();
+
+        String abuseNode = Config.Entry.STATISTICS_CHECK_ABUSE.getNode();
+
+        message.add(new TextComponent(attacker.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(" killing "));
+        message.add(new TextComponent(victim.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(" was not counted as it triggered the 'anti-abuse' system. You can configure " +
+                "the anti-abuse system with config nodes "));
+        message.add(new TextComponent(abuseNode).setColor(ChatColor.AQUA).setUnderlined(true)
+                .setCommand("/pvpstats config set " + abuseNode + " false")
+                .setHoverText(new TextComponent("Click here to disable the abuse system completely!").setColor(ChatColor.RED)));
+        message.add(new TextComponent(" & "));
+        message.add(new TextComponent(Config.Entry.STATISTICS_ABUSE_SECONDS.getNode()).setColor(ChatColor.YELLOW)
+                .setHoverText(new TextComponent("This is the grace period in seconds for which a kill of the same player does not count.")));
+
+        PVPStats.getInstance().sendPrefixedOP(Arrays.asList(attacker.getPlayer(), victim.getPlayer()),
+                message.toArray(new TextComponent[0]));
+    }
+
+    public static void explainNewbieStatus(OfflinePlayer attacker, OfflinePlayer victim) {
+        List<TextComponent> message = new ArrayList<>();
+
+        message.add(new TextComponent(attacker.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(" killing "));
+        message.add(new TextComponent(victim.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(" was not recorded as one or both players have 'newbie' status. Add permission node '"));
+        message.add(new TextComponent("pvpstats.nonewbie").setColor(ChatColor.YELLOW));
+        message.add(new TextComponent("' to both players to fix this."));
+
+        PVPStats.getInstance().sendPrefixedOP(Arrays.asList(attacker.getPlayer(), victim.getPlayer()),
+                message.toArray(new TextComponent[0]));
+    }
+
+    public static void explainIgnoredWorld(Player player) {
+        List<TextComponent> message = new ArrayList<>();
+
+        String world = player.getWorld().getName();
+
+        message.add(new TextComponent("The death of "));
+        message.add(new TextComponent(player.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(" was not counted because the world '"));
+        message.add(new TextComponent(world).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent("' in is in the ignored list. Edit the config node "));
+        message.add(new TextComponent(Config.Entry.IGNORE_WORLDS.getNode()).setColor(ChatColor.AQUA)
+                .setHoverText(
+                        new TextComponent("Click here to remove the world '" + world + "' from the list!").setColor(ChatColor.YELLOW)
+                ).setCommand("/pvpstats config remove " + Config.Entry.IGNORE_WORLDS.getNode() + " " + world));
+        message.add(new TextComponent(" to adjust this."));
+
+        PVPStats.getInstance().sendPrefixedOP(Collections.singletonList(player),
+                message.toArray(new TextComponent[0]));
+    }
+}

--- a/src/main/java/net/slipcor/pvpstats/text/TextFormatter.java
+++ b/src/main/java/net/slipcor/pvpstats/text/TextFormatter.java
@@ -1,6 +1,7 @@
 package net.slipcor.pvpstats.text;
 
 import net.slipcor.pvpstats.PVPStats;
+import net.slipcor.pvpstats.classes.PlayerNameHandler;
 import net.slipcor.pvpstats.core.Config;
 import net.slipcor.pvpstats.core.Language;
 import org.bukkit.Bukkit;
@@ -156,9 +157,9 @@ public class TextFormatter {
 
         String abuseNode = Config.Entry.STATISTICS_CHECK_ABUSE.getNode();
 
-        message.add(new TextComponent(attacker.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(PlayerNameHandler.getPlayerName(attacker)).setColor(ChatColor.YELLOW));
         message.add(new TextComponent(" killing "));
-        message.add(new TextComponent(victim.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(PlayerNameHandler.getPlayerName(victim)).setColor(ChatColor.YELLOW));
         message.add(new TextComponent(" was not counted as it triggered the 'anti-abuse' system. You can configure " +
                 "the anti-abuse system with config nodes "));
         message.add(new TextComponent(abuseNode).setColor(ChatColor.AQUA).setUnderlined(true)
@@ -175,9 +176,9 @@ public class TextFormatter {
     public static void explainNewbieStatus(OfflinePlayer attacker, OfflinePlayer victim) {
         List<TextComponent> message = new ArrayList<>();
 
-        message.add(new TextComponent(attacker.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(PlayerNameHandler.getPlayerName(attacker)).setColor(ChatColor.YELLOW));
         message.add(new TextComponent(" killing "));
-        message.add(new TextComponent(victim.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(PlayerNameHandler.getPlayerName(victim)).setColor(ChatColor.YELLOW));
         message.add(new TextComponent(" was not recorded as one or both players have 'newbie' status. Add permission node '"));
         message.add(new TextComponent("pvpstats.nonewbie").setColor(ChatColor.YELLOW));
         message.add(new TextComponent("' to both players to fix this."));
@@ -192,7 +193,7 @@ public class TextFormatter {
         String world = player.getWorld().getName();
 
         message.add(new TextComponent("The death of "));
-        message.add(new TextComponent(player.getName()).setColor(ChatColor.YELLOW));
+        message.add(new TextComponent(PlayerNameHandler.getPlayerName(player)).setColor(ChatColor.YELLOW));
         message.add(new TextComponent(" was not counted because the world '"));
         message.add(new TextComponent(world).setColor(ChatColor.YELLOW));
         message.add(new TextComponent("' in is in the ignored list. Edit the config node "));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,6 +65,8 @@ statistics:
   assistSeconds: 60
 # === [ Integration into other Plugins ] ===
 other:
+  # use players' display names
+  displayNames: false
   # count PVP Arena deaths
   PVPArena: false
   OPMessages: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: pvpstats
 main: net.slipcor.pvpstats.PVPStats
-version: 1.6.jenkins-build-number
+version: 1.7.jenkins-build-number
 api-version: 1.13
 author: slipcor
 softdepend: [pvparena,PlaceholderAPI]


### PR DESCRIPTION
- **FIX**: debugger not closing debug files properly
- **FIX**: NPEs related to no-pvp-deaths and more
- **FIX**: non-unique config nodes being offered as autocomplete and config set argument
- **FIX**: delay kill streak and ELO messages until after the death message has been sent
- **FEAT**: player display name feature - uses player names formatted by other plugins
- **FEAT**: revamp autocomplete system to allow for partial matches, not only beginning-word-matches
- **FEAT**: TextFormatter API that allows for more distinct highlights and information messages, allow information in hover-over, and issuing commands on clicks 