### PR TITLE
v1.8.14 - add ability to run multiple commands on a streak

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,5 @@
 # v1.X Changelog
+- v1.8.14 - add ability to run multiple commands on a streak
 - v1.8.13 - run streak commands synchronously!
 - v1.8.12 - shift the logic around to make meta restrictions work
 - v1.8.11 - add configurability for numbered entries, support player meta tags (NPC) to exclude from statistics

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
     <version>1.8</version>
     <name>PVP Stats</name>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ This plugin will keep records of how many kills, deaths, kills in a row a player
 
 ## Changelog
 
-- v1.8.13 - run streak commands synchronously!
+- v1.8.14 - add ability to run multiple commands on a streak
 - [read more](doc/changelog.md)
 
 ***

--- a/src/main/java/net/slipcor/pvpstats/PVPStats.java
+++ b/src/main/java/net/slipcor/pvpstats/PVPStats.java
@@ -144,10 +144,24 @@ public class PVPStats extends JavaPlugin {
                     commands = new YamlConfiguration();
                     commands.load(new File(getDataFolder(), "streak_commands.yml"));
                 }
-                String command = commands.getString(key, "");
-                if (!command.isEmpty()) {
-                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(),
-                            command.replace("%player%", PlayerNameHandler.getPlayerName(player)));
+
+                List<String> cmdList = new ArrayList<>();
+
+                // handle either a string or an array of strings in the file
+                if (commands.isString(key)) {
+                    String cmd = commands.getString(key, "");
+                    if (!cmd.equals("")) {
+                        cmdList.add(commands.getString(key, ""));
+                    }
+                } else if (commands.isList(key)) {
+                    cmdList = commands.getStringList(key);
+                }
+
+                for (String command : cmdList) {
+                    if (!command.isEmpty()) {
+                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(),
+                                command.replace("%player%", PlayerNameHandler.getPlayerName(player)));
+                    }
                 }
             }
         } catch (IOException | InvalidConfigurationException exception) {
@@ -231,7 +245,7 @@ public class PVPStats extends JavaPlugin {
         } else {
             dbTable = config().get(Config.Entry.YML_TABLE);
             if (config().getBoolean(Config.Entry.STATISTICS_COLLECT_PRECISE) &&
-                config().getBoolean(Config.Entry.YML_COLLECT_PRECISE)) {
+                    config().getBoolean(Config.Entry.YML_COLLECT_PRECISE)) {
                 dbKillTable = config().get(Config.Entry.MYSQL_KILLTABLE);
             } else if (config().getBoolean(Config.Entry.STATISTICS_COLLECT_PRECISE)) {
                 getLogger().warning("Specific stats can be turned off as they are never used, they are intended for SQL and web frontend usage!");

--- a/src/main/resources/streak_commands.yml
+++ b/src/main/resources/streak_commands.yml
@@ -1,5 +1,14 @@
+# Streak Commands File
+# Format is kills: command
+# OR
+# kills:
+#   - command1
+#   - command2
+
 '5': 'give %player% redstone 1'
 '10': 'give %player% iron_ingot 1'
 '15': 'give %player% diamond 1'
 '20': 'give %player% emerald 2'
-'25': 'give %player% diamond 10'
+'25':
+  - 'give %player% diamond 10'
+  - 'give %player% emerald 2'


### PR DESCRIPTION
The format of the streak yml file is now like so:

```yml
# string method
'5': 'give %player% emerald 2'
# list method
'10':
  - 'give %player% diamond 10'
  - 'give %player% emerald 2'
  ```